### PR TITLE
Feat/batch resize/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ OptimaImg is an image processing toolkit that leverages the performance of Rust 
     - [Adjust Brightness](#adjust-brightness)
     - [Adjust Contrast](#adjust-contrast)
     - [Adjust Hue](#adjust-hue)
+    - [Batch Resize Images](#batch-resize-images)
   - [Benchmarks](#benchmarks)
   - [Contributing](#contributing)
   - [License](#license)
@@ -210,6 +211,21 @@ hue = 1.2  # value > 1 increases contrast, value < 1 decreases contrast
 adjust_hue(input_path, output_path, hue)
 ```
 
+### Batch Resize Images
+
+Batch resize images to the specified dimensions:
+
+```python
+from optimaimg import batch_resize_images
+
+input_images_path = ["path/to/image1", "path/to/image2"]
+output_path = 'path/to/save/images/'
+width = 20
+height = 20
+
+batch_resize_images(input_images_path, output_path, width, height)
+```
+
 ## Benchmarks
 
 Below is a performance comparison table for converting images to grayscale using OptimaImg, Pillow, and OpenCV. The times are measured in seconds and represent the average duration taken to convert a single image across multiple runs.
@@ -231,11 +247,3 @@ Contributions are welcome! Please see `CONTRIBUTING.md` for details on how to co
 ## License
 
 OptimaImg is distributed under the MIT license. See `LICENSE` for more information.
-
-```
-
-```
-
-```
-
-```

--- a/image_processing/__init__.py
+++ b/image_processing/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     adjust_contrast,
     adjust_saturation,
     adjust_hue,
+    batch_resize_images,
 )
 
 __version__ = "0.3.1"
@@ -26,4 +27,5 @@ __all__ = [
     "adjust_contrast",
     "adjust_saturation",
     "adjust_hue",
+    "batch_resize_images",
 ]

--- a/image_processing/core.py
+++ b/image_processing/core.py
@@ -1,3 +1,4 @@
+from typing import List
 from optimaimg import (
     convert_to_grayscale as _convert_to_grayscale,
     resize_image as _resize_image,
@@ -10,6 +11,7 @@ from optimaimg import (
     adjust_contrast as _adjust_contrast,
     adjust_saturation as _adjust_saturation,
     adjust_hue as _adjust_hue,
+    batch_resize_images as _batch_resize_images,
 )
 
 
@@ -173,3 +175,21 @@ def adjust_hue(input_path: str, output_path: str, hue: float) -> None:
     - None: The result of the Rust function, typically None if successful.
     """
     return _adjust_hue(input_path, output_path, hue)
+
+
+def batch_resize_images(
+    input_paths: List[str], output_path: str, width: int, height: int
+) -> None:
+    """
+    Batch resize images to the specified dimensions.
+
+    Parameters:
+    - input_paths (List[str]): A list of paths to the input images.
+    - output_path (str): The path where the resized images will be saved.
+    - width (int): The desired width of the images.
+    - height (int): The desired height of the images.
+
+    Returns:
+    - None: The result of the Rust function, typically None if successful.
+    """
+    return _batch_resize_images(input_paths, output_path, width, height)


### PR DESCRIPTION
This PR introduces the functionality to batch resize multiple images concurrently, saving them to a specified output directory. The update modifies the `batch_resize_images` function to accept a vector of input image paths and a single output directory path, where each resized image is saved with a unique filename. This change streamlines the process of batch processing images, making it more efficient and user-friendly. Error handling is also included to manage and report issues during the resizing process.